### PR TITLE
Problem with getting logs via api when control characters inside strings

### DIFF
--- a/loggersdk.py
+++ b/loggersdk.py
@@ -32,7 +32,7 @@ def post(host, url, data, verify=False, disable_warning=True):
         response.raise_for_status()
         if response.status_code == 200:
             if response.text:
-                response = json.loads(response.text)
+                response = json.loads(response.text, strict=False)
         else:
             response = response.text
     except requests.exceptions.HTTPError as err:


### PR DESCRIPTION
I'm running into issues when queries return results with control characters. The error is like this: 
Invalid control character at: line 1 column 97673 (char 97672)
I traced it down to json lib and when I set strict option to False then I'm able to get the data from search.